### PR TITLE
Fix issue with creating hard links on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ exports.extract = function (cwd, opts) {
     var onlink = function () {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
-        var srcpath = path.join(cwd, path.join('/', header.linkname))
+        var srcpath = path.resolve(cwd, header.linkname)
 
         xfs.link(srcpath, name, function (err) {
           if (err && err.code === 'EPERM' && opts.hardlinkAsFilesFallback) {


### PR DESCRIPTION
This pull request includes a change to the `exports.extract` function in the `index.js` file. The change modifies the way source paths are resolved for links. Instead of joining the current working directory (cwd) and the link name using `path.join`, the code now uses `path.resolve` to determine the source path. This change should provide a more accurate and reliable way to resolve paths.